### PR TITLE
fixed overflow on browse profile, scroll fix

### DIFF
--- a/src/UserContext.tsx
+++ b/src/UserContext.tsx
@@ -40,6 +40,7 @@ export const useDataStore = () => {
   if (!store) {
     throw new Error("useDataStore: !store, did you forget StoreProvider?");
   }
-  console.log('store!!!!', store)
+  // debugging output 
+  // console.log('store!!!!', store)
   return store;
 };

--- a/src/components/Browse/Browse.scss
+++ b/src/components/Browse/Browse.scss
@@ -11,6 +11,7 @@ $cardHeight: 240px;
 }
 
 .browse-container {
+  width: 80vw; // todo: flexboxes in the future
   overflow: clip;
 }
 

--- a/src/components/Browse/BrowseProfiles.tsx
+++ b/src/components/Browse/BrowseProfiles.tsx
@@ -644,7 +644,7 @@ export const BrowseProfiles = () => {
     if (newNotif != null) {
       return (<div className="notification-popup">
       <p className="notification-text">{newNotif.header}</p>
-      <Button className="notification-action-btn">LETS GO</Button>
+      <Button className="notification-action-btn"><Link to={"/complete-profile/0"} style={{ color: "#fff" }}>LETS GO</Link></Button>
       <Button className="notification-close-btn" onClick={() => closeNotification()}>X</Button>
     </div>)
     }

--- a/src/components/Favorites/FavoritesPage.scss
+++ b/src/components/Favorites/FavoritesPage.scss
@@ -6,7 +6,7 @@ div#headerFilter {
     align-items: center;
 }
 
-.favorites-earch-box {
+.favorites-search-box {
     background-color: white;
     padding-left: 10px;
     border: none !important

--- a/src/components/Favorites/FavoritesPage.tsx
+++ b/src/components/Favorites/FavoritesPage.tsx
@@ -185,7 +185,7 @@ const ViewFavoritesPage: React.FC = ({}) => {
         <h3 className="pageHeader">Favorites Profiles</h3>
         <p>You can find all your favorite profiles here</p>
         <div id="headerFilter">
-          <div className="favorites-earch-box">
+          <div className="favorites-search-box">
             <FontAwesomeIcon icon={faSearch} />
             <Tooltip title="Add any word including the cancer type, state, zipcode or city. Example: 1) 20854 Breast Ovarian 2)  VA TNBC 3)   Lung Rockville Gaithersburg 4)   MD DCIS kidney Stage 3">
               <input

--- a/src/layouts/index.scss
+++ b/src/layouts/index.scss
@@ -1,7 +1,8 @@
 @import "../assets/scss/variables.scss";
 
 .default-layout-main {
-  // max-width: 1200px;
+  // max-width: 85vw; 
+  height: 100vh; 
   display: flex;
   background: #f7f7f7;
   justify-content: flex-start;


### PR DESCRIPTION
- defaults-layout-main has been given a height so the concept of scrolling applies
    - edit: error still persists right after sign in, but after refreshing the page it should be fine
- browse-container given a width temporarily to prevent overflow. in the future it's better to consider a well formed flexbox if  possible/incorporating the nav width
- fixed minor spelling error and commmented out debug