### PR TITLE
Fixed message preview runoff

### DIFF
--- a/src/components/Inbox/Inbox.tsx
+++ b/src/components/Inbox/Inbox.tsx
@@ -294,8 +294,8 @@ const Inbox = () => {
               </div>
             </div>
             <div className="conversation-preview">
-              <div>{message.recent.content}</div>
-              <div className="message-icon-orange">23</div>
+              {/* <div>{message.recent.content}</div> 
+              <div className="message-icon-orange">23</div> */}
               
               <div className="maxWidthMessagePreview">{String(message.recent.content).length >= 20 ? String(message.recent.content).substring(0, 20) + " ... " : String(message.recent.content)}</div>
               <div className="message-icon-orange">23</div>

--- a/src/components/Inbox/index.scss
+++ b/src/components/Inbox/index.scss
@@ -57,6 +57,9 @@
 
   .conversation-preview {
     display: flex;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    max-width: 75%;
     justify-content: space-between;
     padding-top:5px;
   }
@@ -302,5 +305,6 @@
 }
 .maxWidthMessagePreview{
   max-width: 80%;
+  text-overflow: ellipsis;
   overflow: hidden;
 }


### PR DESCRIPTION
Sorry for the delay but the conversation pane on the left should now properly cut off long messages in the preview.