### PR TITLE
Browse profile correct flow

### DIFF
--- a/src/UserStore.ts
+++ b/src/UserStore.ts
@@ -191,7 +191,7 @@ export class UserStore {
   @persist phone:string;
   @persist @observable currentChatroom: CurrentChatroomStore;
   @persist chatroomsInitialized: number[];
-  @persist completedProfile: boolean; 
+  @persist completed_profile: boolean; 
 
 
   constructor(){
@@ -215,7 +215,7 @@ export class UserStore {
       this.uniqueLists = localStorageData.uniqueLists;
       this.currentChatroom = localStorageData.currentChatroom;
       this.chatroomsInitialized = localStorageData.chatroomsInitialized;
-      this.completedProfile = localStorage.completed_profile;
+      this.completed_profile = localStorage.completed_profile;
       //this.filterPlusKeywords = localStorageData.filterPlusKeywords;
     } else {
       this.username = "";
@@ -235,7 +235,7 @@ export class UserStore {
       this.savedSearchParams = new SearchParamsStore();
       this.uniqueLists = new UniqueListStore();
       this.chatroomsInitialized = [];
-      this.completedProfile = false;
+      this.completed_profile = false;
       }
      //hydrate('userStore', this).then(() => console.log('userStore has been hydrated'))
      Promise.all([

--- a/src/UserStore.ts
+++ b/src/UserStore.ts
@@ -191,6 +191,7 @@ export class UserStore {
   @persist phone:string;
   @persist @observable currentChatroom: CurrentChatroomStore;
   @persist chatroomsInitialized: number[];
+  @persist completedProfile: boolean; 
 
 
   constructor(){
@@ -214,6 +215,7 @@ export class UserStore {
       this.uniqueLists = localStorageData.uniqueLists;
       this.currentChatroom = localStorageData.currentChatroom;
       this.chatroomsInitialized = localStorageData.chatroomsInitialized;
+      this.completedProfile = localStorage.completed_profile;
       //this.filterPlusKeywords = localStorageData.filterPlusKeywords;
     } else {
       this.username = "";
@@ -233,6 +235,7 @@ export class UserStore {
       this.savedSearchParams = new SearchParamsStore();
       this.uniqueLists = new UniqueListStore();
       this.chatroomsInitialized = [];
+      this.completedProfile = false;
       }
      //hydrate('userStore', this).then(() => console.log('userStore has been hydrated'))
      Promise.all([

--- a/src/components/Browse/Browse.scss
+++ b/src/components/Browse/Browse.scss
@@ -542,3 +542,11 @@ $cardHeight: 240px;
   color: black;
   font-size: initial;
 }
+
+// CSS for the complete profile page that shows up if user didn't complete profile 
+.complete-profile-container {
+  justify-content: center;
+  align-items: center;
+  display: table-cell;
+  vertical-align: middle;
+}

--- a/src/components/Browse/Browse.scss
+++ b/src/components/Browse/Browse.scss
@@ -547,6 +547,14 @@ $cardHeight: 240px;
 .complete-profile-container {
   justify-content: center;
   align-items: center;
-  display: table-cell;
-  vertical-align: middle;
+  display: flex;
+  resize: vertical;
+  flex-direction: column;
+  height: 90vh;
+  width: 80vw;
+}
+
+.complete-profile-message {
+  resize: vertical;
+  display: contents;
 }

--- a/src/components/Browse/CompleteProfile.tsx
+++ b/src/components/Browse/CompleteProfile.tsx
@@ -5,8 +5,10 @@ import { Link } from "react-router-dom";
 export const BrowseProfiles = () => {
     return(
     <div className="complete-profile-container">
-        <div className="pageHeader">Please Complete Your Profile to Begin Matching</div>
-        <Button><Link to="/complete-profile/0" style={{color:"#fff"}}>Complete Profile Here</Link></Button>
+        <div className ="complete-profile-message">
+            <div className="pageHeader">Please Complete Your Profile to Begin Matching</div>
+            <Button><Link to="/complete-profile/0" style={{color:"#fff"}}>Complete Profile Here</Link></Button>
+        </div>
     </div>
     );
 }

--- a/src/components/Browse/CompleteProfile.tsx
+++ b/src/components/Browse/CompleteProfile.tsx
@@ -1,0 +1,14 @@
+import React, { useState, useEffect } from "react";
+import Button from '../../components/Styled/Button';
+import { Link } from "react-router-dom";
+
+export const BrowseProfiles = () => {
+    return(
+    <div className="complete-profile-container">
+        <div className="pageHeader">Please Complete Your Profile to Begin Matching</div>
+        <Button><Link to="/complete-profile/0" style={{color:"#fff"}}>Complete Profile Here</Link></Button>
+    </div>
+    );
+}
+
+export default BrowseProfiles;

--- a/src/components/LogIn/SignIn2.jsx
+++ b/src/components/LogIn/SignIn2.jsx
@@ -91,7 +91,7 @@ const SignIn2 = () => {
               store.uniqueLists.unique_zipcodes = result.data.unique_zipcodes;
               store.uniqueLists.unique_cities = result.data.unique_cities;
               store.savedSearchParams = new SearchParamsStore();
-              store.completedProfile = result.data.completed_profile; 
+              store.completed_profile = result.data.completed_profile; 
 
               if (result.data.search_params) {
                 store.savedSearchParams = result.data.search_params;

--- a/src/components/LogIn/SignIn2.jsx
+++ b/src/components/LogIn/SignIn2.jsx
@@ -118,10 +118,12 @@ const SignIn2 = () => {
             if (store.user_confirmed)
               history.push("/home");
             else {
-              if (store.profile.step_status == STEP_EMAIL_CONFIRMATION_SENT)
-                 history.push("/wizard/5");
-              else
-              history.push("/wizard/0");
+              // todo: investigate why this is here
+              // if (store.profile.step_status == STEP_EMAIL_CONFIRMATION_SENT)
+              //   //  history.push("/wizard/5");
+              // else
+              // history.push("/wizard/0");
+            history.push("/login")
             }
           } else {
             history.push("/login")

--- a/src/components/LogIn/SignIn2.jsx
+++ b/src/components/LogIn/SignIn2.jsx
@@ -74,6 +74,7 @@ const SignIn2 = () => {
             });
               console.log(JSON.stringify(result));
               console.log(result.data.username);
+
               store.username =  result.data.username;
               store.current_user_id = result.data.current_user_id;
               store.email = result.data.email;
@@ -90,11 +91,14 @@ const SignIn2 = () => {
               store.uniqueLists.unique_zipcodes = result.data.unique_zipcodes;
               store.uniqueLists.unique_cities = result.data.unique_cities;
               store.savedSearchParams = new SearchParamsStore();
+              store.completedProfile = result.data.completed_profile; 
+
               if (result.data.search_params) {
                 store.savedSearchParams = result.data.search_params;
               }
               console.log(JSON.stringify(store.savedSearchParams));
               localStorage.setItem("userStore", JSON.stringify(store));
+
           } catch (error) {
             console.log(error.message);
             if (error.message.includes("401")) {

--- a/src/components/Register/Forms/Q10_ReasonsActive.tsx
+++ b/src/components/Register/Forms/Q10_ReasonsActive.tsx
@@ -11,7 +11,7 @@ import { displayToast } from '../../Toast/Toast';
 import { createBrowserHistory } from 'history'
 import {STEP_EMAIL_CONFIRMATION_SENT} from "../../../constants/ProfileConstants";
 
-const sleep = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
+// const sleep = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
 
 const PromptIfDirty = () => {
   const formik = useFormikContext();

--- a/src/components/Register/Forms/Q13_WhereActive.tsx
+++ b/src/components/Register/Forms/Q13_WhereActive.tsx
@@ -11,7 +11,7 @@ import { displayToast } from '../../Toast/Toast';
 import { createBrowserHistory } from 'history'
 import {STEP_EMAIL_CONFIRMATION_SENT} from "../../../constants/ProfileConstants";
 
-const sleep = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
+// const sleep = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
 
 const PromptIfDirty = () => {
   const formik = useFormikContext();

--- a/src/components/Register/Forms/Q14_FitnessLevel.tsx
+++ b/src/components/Register/Forms/Q14_FitnessLevel.tsx
@@ -13,7 +13,7 @@ import { displayToast } from '../../Toast/Toast';
 import { createBrowserHistory } from 'history'
 import {STEP_EMAIL_CONFIRMATION_SENT} from "../../../constants/ProfileConstants";
 
-const sleep = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
+// const sleep = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
 
 const PromptIfDirty = () => {
   const formik = useFormikContext();

--- a/src/components/Register/Forms/Q15_WhenActive.tsx
+++ b/src/components/Register/Forms/Q15_WhenActive.tsx
@@ -13,7 +13,7 @@ import { displayToast } from '../../Toast/Toast';
 import { createBrowserHistory } from 'history'
 import {STEP_EMAIL_CONFIRMATION_SENT} from "../../../constants/ProfileConstants";
 
-const sleep = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
+// const sleep = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
 
 const PromptIfDirty = () => {
   const formik = useFormikContext();

--- a/src/components/Register/Forms/Q16_MainReason.tsx
+++ b/src/components/Register/Forms/Q16_MainReason.tsx
@@ -13,7 +13,7 @@ import { displayToast } from '../../Toast/Toast';
 import { createBrowserHistory } from 'history'
 import {STEP_EMAIL_CONFIRMATION_SENT} from "../../../constants/ProfileConstants";
 
-const sleep = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
+// const sleep = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
 
 const PromptIfDirty = () => {
   const formik = useFormikContext();

--- a/src/components/Register/Forms/Q17_UploadPhoto.tsx
+++ b/src/components/Register/Forms/Q17_UploadPhoto.tsx
@@ -13,6 +13,7 @@ import { displayToast } from '../../Toast/Toast';
 import { createBrowserHistory } from 'history'
 import { STEP_EMAIL_CONFIRMATION_SENT } from "../../../constants/ProfileConstants";
 import AddAPhotoIcon from '@mui/icons-material/AddAPhoto';
+import { Link } from 'react-router-dom';
 
 const sleep = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
 
@@ -65,6 +66,12 @@ const Q17_UploadPhoto = () => {
     setCompleted(0);
   }
 
+  const completeProfile = (e) => {
+    e.preventDefault();
+    store.completed_profile = true; 
+    localStorage.setItem("userStore", JSON.stringify(store));
+  }
+
   const refreshPhoto = () => {
     const fetchProfile = async () => {
       try {
@@ -77,13 +84,19 @@ const Q17_UploadPhoto = () => {
             }
           })
         //   console.log(JSON.stringify(result));
+
         if (result) {
           console.log("In refresh photo");
           console.log(JSON.stringify(result.data.profile.photo));
           store.avatarPath = result.data.profile.photo;
           store.profile.photo = result.data.profile.photo;
+          store.completed_profile = true; 
           localStorage.setItem("userStore", JSON.stringify(store));
         }
+
+        localStorage.setItem("userStore", JSON.stringify(store));
+        console.log(store);
+
       } catch (e) {
         console.log(`😱 Profile Fetch failed: ${e}`);
       }
@@ -179,6 +192,7 @@ const Q17_UploadPhoto = () => {
               let url = PROFILEURL + "/" + store.profile.id + "/update_steps_json";
 
               profile.reason_for_match = values.main_reason;
+              profile.completed_profile = true; 
 
               // Saving data on server
               const res = await axios.patch(url,
@@ -187,12 +201,14 @@ const Q17_UploadPhoto = () => {
               )
               displayToast("Successfully updated profile ✅", "success", 3000, "top-right")
               store.profile = profile;
+              store.completed_profile = true; 
+              // console.log(store);
               localStorage.setItem("userStore", JSON.stringify(store));
 
               if (prevSubmitted) {
                 history.push("/complete-profile/16");
               } else {
-                history.push("/complete-profile/17");
+                history.push("/home");
               }
 
             } catch (err) {
@@ -258,7 +274,8 @@ const Q17_UploadPhoto = () => {
 
               </div>
 
-              
+              {/*  dummy field to make stuff run */}
+              <Field style={{ display: 'none'}} id="hi" type="radio" name="personality" value="hi"></Field>
 
               <PromptIfDirty />
 
@@ -270,6 +287,7 @@ const Q17_UploadPhoto = () => {
               <Button type="submit" margin="2em 1.5em" padding="10px 20px" disabled={isSubmitting}>
                 Next
               </Button>
+              
             </div>
 
           </Form>

--- a/src/components/Register/Forms/Q1_Personality.tsx
+++ b/src/components/Register/Forms/Q1_Personality.tsx
@@ -30,7 +30,7 @@ const Q1_Personality = () => {
 
   useEffect(() => {
     if (store.profile.step_status == STEP_EMAIL_CONFIRMATION_SENT) {
-      history.push("/complete-profile/5");
+      // history.push("/complete-profile/5");
     }
   }, [])
 

--- a/src/components/Register/Forms/Q1_Personality.tsx
+++ b/src/components/Register/Forms/Q1_Personality.tsx
@@ -61,6 +61,10 @@ const Q1_Personality = () => {
           const fetchData = async () => {
             try {
               let url = PROFILEURL + "/" + store.profile.id + "/update_steps_json";
+
+              console.log(store);
+
+              throw "hahah testing";
               //About Me
               profile.personality = values.personality;
               profile.work_status = values.work_status;

--- a/src/components/Register/Forms/Q1_Personality.tsx
+++ b/src/components/Register/Forms/Q1_Personality.tsx
@@ -11,7 +11,7 @@ import { displayToast } from '../../Toast/Toast';
 import { createBrowserHistory } from 'history'
 import {STEP_EMAIL_CONFIRMATION_SENT} from "../../../constants/ProfileConstants";
 
-const sleep = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
+// const sleep = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
 
 const PromptIfDirty = () => {
   const formik = useFormikContext();
@@ -62,13 +62,11 @@ const Q1_Personality = () => {
             try {
               let url = PROFILEURL + "/" + store.profile.id + "/update_steps_json";
 
-              console.log(store);
-
-              throw "hahah testing";
               //About Me
               profile.personality = values.personality;
               profile.work_status = values.work_status;
               profile.details_about_self = values.details_about_self;
+
               // Saving data on server
               const res = await axios.patch(url,
                               { profile: profile },
@@ -76,7 +74,9 @@ const Q1_Personality = () => {
                             )
               displayToast("Successfully updated profile ✅", "success", 3000, "top-right")
               store.profile = profile;
+
               localStorage.setItem("userStore", JSON.stringify(store));
+
               history.push("/complete-profile/1");
             } catch (err) {
               displayToast("Failed to update profile", "error", 3000, "top-right")

--- a/src/components/Register/Forms/Q2_Work.tsx
+++ b/src/components/Register/Forms/Q2_Work.tsx
@@ -36,7 +36,7 @@ const Q2_Work = () => {
 
   useEffect(() => {
     if (store.profile.step_status == STEP_EMAIL_CONFIRMATION_SENT) {
-      history.push("/complete-profile/5");
+      // history.push("/complete-profile/5");
     }
   }, [])
 

--- a/src/components/Register/Forms/Q3_ShareAnything.tsx
+++ b/src/components/Register/Forms/Q3_ShareAnything.tsx
@@ -35,7 +35,7 @@ const Q3_ShareAnything = () => {
 
   useEffect(() => {
     if (store.profile.step_status == STEP_EMAIL_CONFIRMATION_SENT) {
-      history.push("/complete-profile/5");
+      // history.push("/complete-profile/5");
     }
   }, [])
 

--- a/src/components/Register/Forms/Q4_PrimaryDiagnosis.tsx
+++ b/src/components/Register/Forms/Q4_PrimaryDiagnosis.tsx
@@ -35,7 +35,7 @@ const Q4_PrimaryDiagnosis = () => {
 
   useEffect(() => {
     if (store.profile.step_status == STEP_EMAIL_CONFIRMATION_SENT) {
-      history.push("/complete-profile/5");
+      // history.push("/complete-profile/5");
     }
   }, [])
 

--- a/src/components/Register/Forms/Q5_DescribeDiagnoses.tsx
+++ b/src/components/Register/Forms/Q5_DescribeDiagnoses.tsx
@@ -11,7 +11,7 @@ import { displayToast } from '../../Toast/Toast';
 import { createBrowserHistory } from 'history'
 import {STEP_EMAIL_CONFIRMATION_SENT} from "../../../constants/ProfileConstants";
 
-const sleep = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
+// const sleep = (ms: any) => new Promise(resolve => setTimeout(resolve, ms));
 
 const PromptIfDirty = () => {
   const formik = useFormikContext();

--- a/src/components/Register/Forms/Q5_DescribeDiagnoses.tsx
+++ b/src/components/Register/Forms/Q5_DescribeDiagnoses.tsx
@@ -33,7 +33,7 @@ const Q5_DescribeDiagnoses = () => {
 
   useEffect(() => {
     if (store.profile.step_status == STEP_EMAIL_CONFIRMATION_SENT) {
-      history.push("/complete-profile/5");
+      // history.push("/complete-profile/5");
     }
   }, [])
 
@@ -43,7 +43,7 @@ const Q5_DescribeDiagnoses = () => {
 
   const handleNext = (event: React.MouseEvent) => {
     event.preventDefault();
-    history.push("/complete-profile/5");
+    // history.push("/complete-profile/5");
   }
   return (
     <div>

--- a/src/components/Register/Forms/Q6_AdditionalCancerInfo.tsx
+++ b/src/components/Register/Forms/Q6_AdditionalCancerInfo.tsx
@@ -35,7 +35,7 @@ const Q6_AdditionalCancerInfo = () => {
 
   useEffect(() => {
     if (store.profile.step_status == STEP_EMAIL_CONFIRMATION_SENT) {
-      history.push("/complete-profile/5");
+      // history.push("/complete-profile/5");
     }
   }, [])
 

--- a/src/components/Register/Forms/Q7_DescribeTreatments.tsx
+++ b/src/components/Register/Forms/Q7_DescribeTreatments.tsx
@@ -35,7 +35,7 @@ const Q7_DescribeTreatments = () => {
 
   useEffect(() => {
     if (store.profile.step_status == STEP_EMAIL_CONFIRMATION_SENT) {
-      history.push("/complete-profile/5");
+      // history.push("/complete-profile/5");
     }
   }, [])
 

--- a/src/components/manageProfile/UploadPhoto.js
+++ b/src/components/manageProfile/UploadPhoto.js
@@ -38,7 +38,7 @@ const UploadPhoto = (props) => {
 
   useEffect(() => {
     if (fromWizard && (store.profile.step_status == STEP_EMAIL_CONFIRMATION_SENT)) {
-      history.push("/wizard/5");
+      // history.push("/wizard/5");
     }
   }, []);
 

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -2,7 +2,9 @@ import React from 'react'
 import BrowseProfiles from '../components/Browse/BrowseProfiles'
 import {useDataStore} from "../UserContext";
 import Default from '../layouts/Default';
-import {Redirect} from 'react-router-dom'
+import {Redirect} from 'react-router-dom';
+import CompleteProfile from '../components/Browse/CompleteProfile' 
+
 
 export default function Home() {
   const storedData = localStorage.getItem("userStore");
@@ -11,14 +13,18 @@ export default function Home() {
   if (!storedData && ((store && !store.isLoggedIn))) {
     return <Redirect to="/login" />
   }
-
-  if (!store.user_confirmed) {
-    return <Redirect to="/complete-profile/0" />
-  }
   
+  if (JSON.parse(storedData).completed_profile == true) {
   return (
     <Default>
-      <BrowseProfiles />
+      <BrowseProfiles/>
     </Default>
   )
+  } else {
+    return (
+      <Default>
+        <CompleteProfile/>
+      </Default>
+    )
+  }
 }


### PR DESCRIPTION
The flow is correct now, save for the notification to "finish profile" that still shows up.

Note that if you log in as all users save for admin1, admin2, and dash, you'll find you'll have to go through the sign up flow because I didn't manually update the db to reflect which profiles were complete.

Also the redirection bug should be... less? as well now. I would do a post mortem on who made the SignIn2 page because I believe the copy paste there was so strong that the app decided to redirect a whole bunch of times.
